### PR TITLE
check if there are messages before looking for an index

### DIFF
--- a/src/PhpAbbyy.php
+++ b/src/PhpAbbyy.php
@@ -164,7 +164,7 @@ class PhpAbbyy
         $response = $this->client->request('GET', "{$this->apiPath}/jobs/{$jobId}/result");
         $content = $response->toArray();
 
-        if($content['Messages'][0]['Type'] === "JMT_Error")
+        if($content['Messages'] && $content['Messages'][0]['Type'] === "JMT_Error")
         {
             $this->responseObject['errors'][] = $content['Messages'][0]['UnicodeStr'];
             return true;


### PR DESCRIPTION
check if there are messages before looking for an index in the response. 
This was causing a "Warning: Undefined array key 0" and also not letting the alternate files be created,